### PR TITLE
Fix @handler validation with postponed annotations in Executor

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_executor.py
@@ -7,7 +7,7 @@ import inspect
 import logging
 import types
 from collections.abc import Awaitable, Callable
-from typing import Any, TypeVar, overload
+from typing import Any, TypeVar, get_type_hints, overload
 
 from ..observability import create_processing_span
 from ._events import (
@@ -508,7 +508,7 @@ class Executor(RequestInfoMixin, DictConvertible):
         """Hook called when the workflow is restored from a checkpoint.
 
         Override this method in subclasses to implement custom logic that should
-        run when the workflow is restored from a checkpoint.
+        run when the workflow is restored from the checkpoint.
 
         Args:
             state: The state dictionary that was saved during checkpointing.
@@ -717,25 +717,35 @@ def _validate_handler_signature(
     if len(params) != expected_counts:
         raise ValueError(f"Handler {func.__name__} must have {param_description}. Got {len(params)} parameters.")
 
+    resolved_hints: dict[str, Any] = {}
+    with contextlib.suppress(Exception):
+        # Prefer include_extras for Annotated/etc. when available.
+        resolved_hints = get_type_hints(
+            func,
+            globalns=getattr(func, "__globals__", None),
+            include_extras=True,  # type: ignore[call-arg]
+        )
+
     # Check message parameter has type annotation (unless skipped)
     message_param = params[1]
-    if not skip_message_annotation and message_param.annotation == inspect.Parameter.empty:
+    message_annotation = resolved_hints.get(message_param.name, message_param.annotation)
+    if not skip_message_annotation and message_annotation == inspect.Parameter.empty:
         raise ValueError(f"Handler {func.__name__} must have a type annotation for the message parameter")
 
     # Validate ctx parameter is WorkflowContext and extract type args
     ctx_param = params[2]
-    if skip_message_annotation and ctx_param.annotation == inspect.Parameter.empty:
+    ctx_annotation = resolved_hints.get(ctx_param.name, ctx_param.annotation)
+    if skip_message_annotation and ctx_annotation == inspect.Parameter.empty:
         # When explicit types are provided via @handler(input=..., output=...),
         # the ctx parameter doesn't need a type annotation - types come from the decorator.
         output_types: list[type[Any] | types.UnionType] = []
         workflow_output_types: list[type[Any] | types.UnionType] = []
     else:
         output_types, workflow_output_types = validate_workflow_context_annotation(
-            ctx_param.annotation, f"parameter '{ctx_param.name}'", "Handler"
+            ctx_annotation, f"parameter '{ctx_param.name}'", "Handler"
         )
 
-    message_type = message_param.annotation if message_param.annotation != inspect.Parameter.empty else None
-    ctx_annotation = ctx_param.annotation
+    message_type = message_annotation if message_annotation != inspect.Parameter.empty else None
 
     return message_type, ctx_annotation, output_types, workflow_output_types
 

--- a/python/packages/core/tests/workflow/test_executor_future.py
+++ b/python/packages/core/tests/workflow/test_executor_future.py
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from agent_framework import Executor, WorkflowContext, handler
+
+
+@dataclass
+class FutureTypeA:
+    v: str
+
+
+@dataclass
+class FutureTypeB:
+    v: int
+
+
+class TestExecutorFutureAnnotations:
+    """Tests for Executor/@handler when `from __future__ import annotations` is enabled."""
+
+    def test_handler_decorator_future_annotations_resolves_ctx_generic(self) -> None:
+        """Executor subclass definition should not raise when ctx annotation is stringified."""
+
+        class MyExecutor(Executor):
+            @handler
+            async def example(self, input: str, ctx: WorkflowContext[FutureTypeA, FutureTypeB]) -> None:
+                pass
+
+        # Instantiation triggers handler discovery and uses resolved annotations
+        exec_instance = MyExecutor(id="future")
+
+        # User-observable behavior: executor has handler registered for `str`
+        assert str in exec_instance._handlers
+
+        # And declared workflow output types were inferred
+        assert FutureTypeA in exec_instance.output_types
+        assert FutureTypeB in exec_instance.workflow_output_types
+
+    def test_handler_decorator_future_annotations_resolves_message_type(self) -> None:
+        """Message type should be resolved to actual typing object (not a string)."""
+
+        class ComplexInputExecutor(Executor):
+            @handler
+            async def example(self, input: dict[str, Any], ctx: WorkflowContext) -> None:
+                pass
+
+        exec_instance = ComplexInputExecutor(id="complex")
+
+        spec = exec_instance._handler_specs[0]
+        assert spec["message_type"] == dict[str, Any]


### PR DESCRIPTION
Fixes Executor handler signature validation when `from __future__ import annotations` causes `inspect.signature()` annotations to be strings.

Changes:
- Resolve handler parameter annotations via `typing.get_type_hints(..., include_extras=True)` in `_validate_handler_signature`.
- Use resolved message/ctx annotations for WorkflowContext validation and message type registration.
- Add regression tests covering stringified `WorkflowContext[T, U]` and complex message typing (e.g. `dict[str, Any]`).

This keeps explicit `@handler(input=..., output=...)` behavior unchanged; only the introspection path is affected.