### PR TITLE
Fix Executor @handler validation with postponed annotations

### DIFF
--- a/python/packages/core/tests/workflow/test_executor_future.py
+++ b/python/packages/core/tests/workflow/test_executor_future.py
@@ -1,0 +1,51 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_framework import Executor, WorkflowContext, handler
+
+
+class TypeA:
+    pass
+
+
+class TypeB:
+    pass
+
+
+class TypeC:
+    pass
+
+
+class FutureAnnotationsExecutor(Executor):
+    """Executor used to validate @handler type introspection with postponed annotations."""
+
+    @handler
+    async def example(self, message: str, ctx: WorkflowContext[TypeA, TypeB]) -> None:
+        # No runtime behavior needed for this test; decoration/registration should succeed.
+        return None
+
+    @handler
+    async def union_example(self, message: dict[str, Any], ctx: WorkflowContext[TypeA | TypeB, TypeC]) -> None:
+        return None
+
+
+class TestExecutorFutureAnnotations:
+    def test_executor_handler_future_annotations_resolve_ctx(self) -> None:
+        """Ensure ctx annotations are evaluated (not strings) before validation."""
+        ex = FutureAnnotationsExecutor(id="ex")
+
+        # Handler registration should succeed, and output/workflow output inference should work.
+        assert TypeA in ex.output_types
+        assert TypeB in ex.workflow_output_types
+
+    def test_executor_handler_future_annotations_resolve_unions(self) -> None:
+        """Ensure union args inside WorkflowContext are correctly inferred."""
+        ex = FutureAnnotationsExecutor(id="ex2")
+
+        # union_example declares OutT = TypeA | TypeB and W_OutT = TypeC
+        assert TypeA in ex.output_types
+        assert TypeB in ex.output_types
+        assert TypeC in ex.workflow_output_types


### PR DESCRIPTION
Fixes a false-negative WorkflowContext validation when handlers are defined under `from __future__ import annotations`.

- Resolve handler parameter annotations via `typing.get_type_hints(..., include_extras=True)` inside `_validate_handler_signature` before calling `validate_workflow_context_annotation`.
- Store the resolved message/context annotations in handler specs so downstream inference uses evaluated typing objects.
- Add regression tests ensuring `Executor` handler registration and output/workflow-output inference works with postponed annotations, including union type arguments.

Fixes #1.