### PR TITLE
Fix Executor @handler with postponed annotations (__future__.annotations)

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_executor.py
@@ -7,7 +7,7 @@ import inspect
 import logging
 import types
 from collections.abc import Awaitable, Callable
-from typing import Any, TypeVar, overload
+from typing import Any, TypeVar, get_type_hints, overload
 
 from ..observability import create_processing_span
 from ._events import (
@@ -508,7 +508,7 @@ class Executor(RequestInfoMixin, DictConvertible):
         """Hook called when the workflow is restored from a checkpoint.
 
         Override this method in subclasses to implement custom logic that should
-        run when the workflow is restored from a checkpoint.
+        run when the workflow is restored from the checkpoint.
 
         Args:
             state: The state dictionary that was saved during checkpointing.
@@ -717,25 +717,40 @@ def _validate_handler_signature(
     if len(params) != expected_counts:
         raise ValueError(f"Handler {func.__name__} must have {param_description}. Got {len(params)} parameters.")
 
+    type_hints: dict[str, Any] = {}
+    try:
+        type_hints = get_type_hints(func, globalns=getattr(func, "__globals__", None), include_extras=True)
+    except (NameError, TypeError):
+        type_hints = {}
+
     # Check message parameter has type annotation (unless skipped)
     message_param = params[1]
-    if not skip_message_annotation and message_param.annotation == inspect.Parameter.empty:
+    message_annotation = type_hints.get(message_param.name, message_param.annotation)
+    if not skip_message_annotation and message_annotation == inspect.Parameter.empty:
         raise ValueError(f"Handler {func.__name__} must have a type annotation for the message parameter")
 
     # Validate ctx parameter is WorkflowContext and extract type args
     ctx_param = params[2]
-    if skip_message_annotation and ctx_param.annotation == inspect.Parameter.empty:
+    ctx_annotation = type_hints.get(ctx_param.name, ctx_param.annotation)
+    if skip_message_annotation and ctx_annotation == inspect.Parameter.empty:
         # When explicit types are provided via @handler(input=..., output=...),
         # the ctx parameter doesn't need a type annotation - types come from the decorator.
         output_types: list[type[Any] | types.UnionType] = []
         workflow_output_types: list[type[Any] | types.UnionType] = []
     else:
+        if isinstance(ctx_annotation, str):
+            raise ValueError(
+                f"Handler parameter '{ctx_param.name}' annotation could not be resolved. "
+                "If you're using 'from __future__ import annotations', ensure the "
+                "WorkflowContext[...] type and its generic parameters are importable in the module "
+                "where the handler is defined."
+            )
+
         output_types, workflow_output_types = validate_workflow_context_annotation(
-            ctx_param.annotation, f"parameter '{ctx_param.name}'", "Handler"
+            ctx_annotation, f"parameter '{ctx_param.name}'", "Handler"
         )
 
-    message_type = message_param.annotation if message_param.annotation != inspect.Parameter.empty else None
-    ctx_annotation = ctx_param.annotation
+    message_type = message_annotation if message_annotation != inspect.Parameter.empty else None
 
     return message_type, ctx_annotation, output_types, workflow_output_types
 

--- a/python/packages/core/tests/workflow/test_executor_future.py
+++ b/python/packages/core/tests/workflow/test_executor_future.py
@@ -1,0 +1,49 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from agent_framework import Executor, WorkflowContext, handler
+
+
+@dataclass
+class MyTypeA:
+    value: str
+
+
+@dataclass
+class MyTypeB:
+    value: int
+
+
+class TestExecutorFutureAnnotations:
+    """Regression tests for Executor handler discovery with postponed annotations."""
+
+    def test_handler_future_annotations_resolved_for_context_generics(self) -> None:
+        class MyExecutor(Executor):
+            @handler
+            async def example(self, input: str, ctx: WorkflowContext[MyTypeA, MyTypeB]) -> None:
+                pass
+
+        exec_instance = MyExecutor(id="test")
+
+        handler_func = exec_instance._handlers[str]
+        spec = handler_func._handler_spec
+
+        assert spec["message_type"] is str
+        assert spec["output_types"] == [MyTypeA]
+        assert spec["workflow_output_types"] == [MyTypeB]
+
+        assert MyTypeA in exec_instance.output_types
+        assert MyTypeB in exec_instance.workflow_output_types
+
+    def test_handler_future_annotations_unresolvable_raises_clear_error(self) -> None:
+        with pytest.raises(ValueError, match="could not be resolved"):
+
+            class BadExecutor(Executor):
+                @handler
+                async def example(self, input: str, ctx: "WorkflowContext[MissingType]") -> None:  # type: ignore[name-defined]
+                    pass


### PR DESCRIPTION
Fixes handler signature validation and output type inference for Executor when annotations are postponed (from __future__ import annotations / Python 3.12).

- Use typing.get_type_hints(..., include_extras=True) in _validate_handler_signature to resolve ctx/message annotations before validation.
- Provide a clearer error if ctx annotation remains a string (unresolvable forward reference).
- Add regression tests covering successful generic WorkflowContext[A, B] inference and the unresolvable-forward-ref error path.

Fixes #1.