### PR TITLE
Fix Executor @handler validation with postponed annotations

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_executor.py
@@ -7,7 +7,7 @@ import inspect
 import logging
 import types
 from collections.abc import Awaitable, Callable
-from typing import Any, TypeVar, overload
+from typing import Any, TypeVar, get_type_hints, overload
 
 from ..observability import create_processing_span
 from ._events import (
@@ -508,7 +508,7 @@ class Executor(RequestInfoMixin, DictConvertible):
         """Hook called when the workflow is restored from a checkpoint.
 
         Override this method in subclasses to implement custom logic that should
-        run when the workflow is restored from a checkpoint.
+        run when the workflow is restored from the checkpoint.
 
         Args:
             state: The state dictionary that was saved during checkpointing.
@@ -717,25 +717,33 @@ def _validate_handler_signature(
     if len(params) != expected_counts:
         raise ValueError(f"Handler {func.__name__} must have {param_description}. Got {len(params)} parameters.")
 
+    # Resolve postponed annotations (PEP 563 / __future__.annotations) using typing.get_type_hints
+    # so validation operates on real typing objects instead of raw strings.
+    try:
+        hints = get_type_hints(func, globalns=func.__globals__, localns=None, include_extras=True)
+    except (NameError, TypeError, SyntaxError):
+        hints = {}
+
     # Check message parameter has type annotation (unless skipped)
     message_param = params[1]
-    if not skip_message_annotation and message_param.annotation == inspect.Parameter.empty:
+    message_annotation = hints.get(message_param.name, message_param.annotation)
+    if not skip_message_annotation and message_annotation == inspect.Parameter.empty:
         raise ValueError(f"Handler {func.__name__} must have a type annotation for the message parameter")
 
     # Validate ctx parameter is WorkflowContext and extract type args
     ctx_param = params[2]
-    if skip_message_annotation and ctx_param.annotation == inspect.Parameter.empty:
+    ctx_annotation = hints.get(ctx_param.name, ctx_param.annotation)
+    if skip_message_annotation and ctx_annotation == inspect.Parameter.empty:
         # When explicit types are provided via @handler(input=..., output=...),
         # the ctx parameter doesn't need a type annotation - types come from the decorator.
         output_types: list[type[Any] | types.UnionType] = []
         workflow_output_types: list[type[Any] | types.UnionType] = []
     else:
         output_types, workflow_output_types = validate_workflow_context_annotation(
-            ctx_param.annotation, f"parameter '{ctx_param.name}'", "Handler"
+            ctx_annotation, f"parameter '{ctx_param.name}'", "Handler"
         )
 
-    message_type = message_param.annotation if message_param.annotation != inspect.Parameter.empty else None
-    ctx_annotation = ctx_param.annotation
+    message_type = message_annotation if message_annotation != inspect.Parameter.empty else None
 
     return message_type, ctx_annotation, output_types, workflow_output_types
 

--- a/python/packages/core/tests/workflow/test_executor_future.py
+++ b/python/packages/core/tests/workflow/test_executor_future.py
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic import BaseModel
+
+from agent_framework import Executor, WorkflowContext, handler
+
+
+class MyTypeA(BaseModel):
+    pass
+
+
+class MyTypeB(BaseModel):
+    pass
+
+
+def test_handler_decorator_supports_future_annotations_workflow_context_generics() -> None:
+    """Regression: @handler should accept WorkflowContext[T, U] when annotations are postponed."""
+
+    class FutureCtxExecutor(Executor):
+        @handler
+        async def example(self, input: str, ctx: WorkflowContext[MyTypeA, MyTypeB]) -> None:
+            pass
+
+    # Instantiation triggers handler discovery/validation.
+    exec_instance = FutureCtxExecutor(id="future_ctx")
+
+    assert str in exec_instance._handlers
+    # Ensure output/workflow_output types were correctly inferred.
+    assert exec_instance.output_types == [MyTypeA]
+    assert exec_instance.workflow_output_types == [MyTypeB]
+
+
+def test_handler_decorator_supports_future_annotations_forward_ref_message_type() -> None:
+    """Regression: message annotations should be resolved so routing doesn't store a raw string."""
+
+    @dataclass
+    class MyMessage:
+        content: str
+
+    class ForwardRefMsgExecutor(Executor):
+        @handler
+        async def example(self, message: "MyMessage", ctx: WorkflowContext) -> None:
+            pass
+
+    exec_instance = ForwardRefMsgExecutor(id="forward_ref_msg")
+
+    # If message annotation isn't resolved, handler would be registered under a string key,
+    # which breaks routing via isinstance checks.
+    assert MyMessage in exec_instance._handlers


### PR DESCRIPTION
Fixes handler signature validation when `from __future__ import annotations` is enabled.

Problem:
- `_validate_handler_signature` used raw `inspect.signature(...).parameters[i].annotation` values.
- Under postponed annotations those are strings, so `validate_workflow_context_annotation()` (which uses `typing.get_origin/get_args`) could not recognize `WorkflowContext[...]`, raising `ValueError`.
- Message parameter annotations could also remain strings, causing handler registration keys that break routing.

Solution:
- Resolve annotations in `_validate_handler_signature` using `typing.get_type_hints(..., include_extras=True)` with the function’s module globals.
- Fall back to raw annotations if hints can’t be resolved.

Tests:
- Add regression tests for:
  - `WorkflowContext[T, U]` generic ctx annotation under postponed annotations
  - forward-referenced message type resolution so handler registration/routing works

Issue: #1