### PR TITLE
Fix Executor @handler validation with postponed annotations (Python 3.12)

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_executor.py
@@ -7,7 +7,7 @@ import inspect
 import logging
 import types
 from collections.abc import Awaitable, Callable
-from typing import Any, TypeVar, overload
+from typing import Any, TypeVar, get_type_hints, overload
 
 from ..observability import create_processing_span
 from ._events import (
@@ -508,7 +508,7 @@ class Executor(RequestInfoMixin, DictConvertible):
         """Hook called when the workflow is restored from a checkpoint.
 
         Override this method in subclasses to implement custom logic that should
-        run when the workflow is restored from a checkpoint.
+        run when the workflow is restored from the checkpoint.
 
         Args:
             state: The state dictionary that was saved during checkpointing.
@@ -717,25 +717,40 @@ def _validate_handler_signature(
     if len(params) != expected_counts:
         raise ValueError(f"Handler {func.__name__} must have {param_description}. Got {len(params)} parameters.")
 
+    type_hints: dict[str, Any] = {}
+    with contextlib.suppress(TypeError, NameError):
+        # Resolve postponed annotations (from __future__ import annotations) and forward refs.
+        try:
+            type_hints = get_type_hints(
+                func,
+                globalns=getattr(func, "__globals__", None),
+                localns=None,
+                include_extras=True,
+            )
+        except TypeError:
+            # include_extras not supported on older Pythons
+            type_hints = get_type_hints(func, globalns=getattr(func, "__globals__", None), localns=None)
+
     # Check message parameter has type annotation (unless skipped)
     message_param = params[1]
-    if not skip_message_annotation and message_param.annotation == inspect.Parameter.empty:
+    message_annotation = type_hints.get(message_param.name, message_param.annotation)
+    if not skip_message_annotation and message_annotation == inspect.Parameter.empty:
         raise ValueError(f"Handler {func.__name__} must have a type annotation for the message parameter")
 
     # Validate ctx parameter is WorkflowContext and extract type args
     ctx_param = params[2]
-    if skip_message_annotation and ctx_param.annotation == inspect.Parameter.empty:
+    ctx_annotation = type_hints.get(ctx_param.name, ctx_param.annotation)
+    if skip_message_annotation and ctx_annotation == inspect.Parameter.empty:
         # When explicit types are provided via @handler(input=..., output=...),
         # the ctx parameter doesn't need a type annotation - types come from the decorator.
         output_types: list[type[Any] | types.UnionType] = []
         workflow_output_types: list[type[Any] | types.UnionType] = []
     else:
         output_types, workflow_output_types = validate_workflow_context_annotation(
-            ctx_param.annotation, f"parameter '{ctx_param.name}'", "Handler"
+            ctx_annotation, f"parameter '{ctx_param.name}'", "Handler"
         )
 
-    message_type = message_param.annotation if message_param.annotation != inspect.Parameter.empty else None
-    ctx_annotation = ctx_param.annotation
+    message_type = message_annotation if message_annotation != inspect.Parameter.empty else None
 
     return message_type, ctx_annotation, output_types, workflow_output_types
 

--- a/python/packages/core/tests/workflow/test_executor_handler_annotations.py
+++ b/python/packages/core/tests/workflow/test_executor_handler_annotations.py
@@ -1,0 +1,60 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Regression tests for handler signature validation with postponed annotations.
+
+This file uses `from __future__ import annotations` so parameter annotations are
+stored as strings and must be resolved via typing.get_type_hints during
+@handler introspection.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from agent_framework import Executor, WorkflowContext, handler
+
+
+class MyTypeA(BaseModel):
+    pass
+
+
+class MyTypeB(BaseModel):
+    pass
+
+
+def test_handler_introspection_resolves_postponed_workflow_context_generic_args() -> None:
+    """Defining a handler under postponed annotations should not raise."""
+
+    class MyExecutor(Executor):
+        @handler
+        async def example(self, input: str, ctx: WorkflowContext[MyTypeA, MyTypeB]) -> None:
+            return None
+
+    # Instantiation triggers handler discovery; should not error.
+    exec_ = MyExecutor(id="e1")
+    assert exec_.input_types == [str]
+
+
+def test_handler_introspection_resolves_nested_forward_refs_in_workflow_context() -> None:
+    """WorkflowContext type arguments may be forward refs (string literals) nested in generics."""
+
+    class MyExecutor(Executor):
+        @handler
+        async def example(self, input: str, ctx: WorkflowContext["MyTypeA", "MyTypeB"]) -> None:
+            return None
+
+    exec_ = MyExecutor(id="e2")
+    assert exec_.input_types == [str]
+
+
+def test_handler_introspection_falls_back_to_raw_annotations_when_unresolvable() -> None:
+    """If get_type_hints fails due to missing names, we should still raise a clear ValueError."""
+
+    class MyExecutor(Executor):
+        @handler
+        async def example(self, input: str, ctx: "WorkflowContext[MissingType]") -> None:  # type: ignore[name-defined]
+            return None
+
+    with pytest.raises(ValueError, match="WorkflowContext"):
+        MyExecutor(id="e3")


### PR DESCRIPTION
Fixes #1.

### What changed
- Resolve postponed/forward-ref annotations during `@handler` introspection by using `typing.get_type_hints(..., include_extras=True)` in `_validate_handler_signature`.
- Fall back to raw `inspect.signature()` annotations if evaluation fails (e.g., unresolved names).

### Why
Under `from __future__ import annotations` (Python 3.12+), parameter annotations are stored as strings; the previous implementation passed these strings to `validate_workflow_context_annotation`, which expects evaluated typing objects and would reject `WorkflowContext[...]`.

### Tests added
- Regression coverage for postponed annotations with `WorkflowContext[MyTypeA, MyTypeB]`.
- Edge case: nested forward refs inside `WorkflowContext["MyTypeA", "MyTypeB"]`.
- Edge case: get_type_hints failure fallback still raises a clear ValueError.
