### PR TITLE
Fix Executor @handler validation for postponed annotations (Python 3.12)

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_executor.py
@@ -709,6 +709,8 @@ def _validate_handler_signature(
     Raises:
         ValueError: If the function signature is invalid
     """
+    import typing
+
     signature = inspect.signature(func)
     params = list(signature.parameters.values())
 
@@ -717,25 +719,34 @@ def _validate_handler_signature(
     if len(params) != expected_counts:
         raise ValueError(f"Handler {func.__name__} must have {param_description}. Got {len(params)} parameters.")
 
+    # Resolve postponed annotations (PEP 563 / __future__.annotations)
+    # so validators receive real types/typing objects rather than strings.
+    try:
+        hints = typing.get_type_hints(func, globalns=getattr(func, "__globals__", {}), localns=None, include_extras=True)
+    except (NameError, TypeError, SyntaxError):
+        hints = {}
+
     # Check message parameter has type annotation (unless skipped)
     message_param = params[1]
-    if not skip_message_annotation and message_param.annotation == inspect.Parameter.empty:
+    message_annotation = hints.get(message_param.name, message_param.annotation)
+    if not skip_message_annotation and message_annotation == inspect.Parameter.empty:
         raise ValueError(f"Handler {func.__name__} must have a type annotation for the message parameter")
 
     # Validate ctx parameter is WorkflowContext and extract type args
     ctx_param = params[2]
-    if skip_message_annotation and ctx_param.annotation == inspect.Parameter.empty:
+    ctx_annotation = hints.get(ctx_param.name, ctx_param.annotation)
+
+    if skip_message_annotation and ctx_annotation == inspect.Parameter.empty:
         # When explicit types are provided via @handler(input=..., output=...),
         # the ctx parameter doesn't need a type annotation - types come from the decorator.
         output_types: list[type[Any] | types.UnionType] = []
         workflow_output_types: list[type[Any] | types.UnionType] = []
     else:
         output_types, workflow_output_types = validate_workflow_context_annotation(
-            ctx_param.annotation, f"parameter '{ctx_param.name}'", "Handler"
+            ctx_annotation, f"parameter '{ctx_param.name}'", "Handler"
         )
 
-    message_type = message_param.annotation if message_param.annotation != inspect.Parameter.empty else None
-    ctx_annotation = ctx_param.annotation
+    message_type = message_annotation if message_annotation != inspect.Parameter.empty else None
 
     return message_type, ctx_annotation, output_types, workflow_output_types
 

--- a/python/packages/core/tests/workflow/test_executor_future_annotations.py
+++ b/python/packages/core/tests/workflow/test_executor_future_annotations.py
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agent_framework import Executor, WorkflowContext, handler
+
+
+@dataclass
+class FutureTypeA:
+    value: str
+
+
+@dataclass
+class FutureTypeB:
+    value: int
+
+
+@dataclass
+class FutureMessage:
+    text: str
+
+
+class TestExecutorFutureAnnotations:
+    def test_executor_handler_future_annotations_inferred_types(self) -> None:
+        """Regression: @handler introspection must resolve stringified annotations."""
+
+        class FutureExecutor(Executor):
+            @handler
+            async def handle(self, message: FutureMessage, ctx: WorkflowContext[FutureTypeA, FutureTypeB]) -> None:
+                pass
+
+        exec_instance = FutureExecutor(id="future_exec")
+
+        # Ensure handler registration uses resolved class, not string
+        assert FutureMessage in exec_instance._handlers
+
+        # Ensure inferred context output types are resolved
+        assert exec_instance.output_types == [FutureTypeA]
+        assert exec_instance.workflow_output_types == [FutureTypeB]
+
+    def test_executor_handler_future_annotations_missing_type_is_error(self) -> None:
+        """Edge case: unresolved forward refs should fail with the existing ctx validation error."""
+
+        try:
+
+            class BadFutureExecutor(Executor):
+                @handler
+                async def handle(self, message: "MissingMessage", ctx: "WorkflowContext[MissingOut]") -> None:
+                    pass
+
+            _ = BadFutureExecutor
+        except ValueError as exc:
+            # When annotations can't be resolved, ctx_annotation remains a string,
+            # and ctx validation should complain about needing WorkflowContext.
+            assert "WorkflowContext" in str(exc)
+        else:
+            raise AssertionError("Expected ValueError due to unresolved annotations")


### PR DESCRIPTION
Fixes #1.

### Problem
Under Python 3.12 with `from __future__ import annotations`, `inspect.signature()` returns string annotations. The regular `Executor` handler signature validation path passed these strings into `validate_workflow_context_annotation`, which expects real typing objects/classes and rejected the stringified `WorkflowContext[...]`.

### Fix
In `_validate_handler_signature` we now resolve postponed annotations via `typing.get_type_hints(..., include_extras=True)` and use the resolved annotations for:
- message type registration/dispatch
- `WorkflowContext` annotation validation and output/workflow_output type inference

If `get_type_hints` fails (e.g., unresolved forward refs), we fall back to the prior behavior.

### Tests
- Added regression tests covering `Executor` + `@handler` with future annotations, including output/workflow_output inference.
- Added an edge-case test ensuring unresolved forward refs still raise a clear `ValueError` during validation.