### PR TITLE
Fix mypy no-untyped-def errors in executor future-annotations tests

### DIFF
--- a/python/packages/core/tests/workflow/test_executor_future.py
+++ b/python/packages/core/tests/workflow/test_executor_future.py
@@ -1,0 +1,55 @@
+# Copyright (c) Microsoft. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from typing_extensions import Never
+
+from agent_framework import Executor, WorkflowContext, handler
+
+
+@dataclass
+class MyTypeA:
+    x: int = 1
+
+
+@dataclass
+class MyTypeB:
+    y: int = 2
+
+
+class TestExecutorFutureAnnotations:
+    """Regression tests for Executor/@handler with from __future__ import annotations.
+
+    When future annotations are enabled, annotations are stored as strings and must be
+    resolved before calling validate_workflow_context_annotation.
+    """
+
+    def test_handler_future_annotations_workflow_context_two_params(self) -> None:
+        class MyExecutor(Executor):
+            @handler
+            async def example(self, input: str, ctx: WorkflowContext[MyTypeA, MyTypeB]) -> None:
+                pass
+
+        ex = MyExecutor(id="x")
+
+        # Validate handler spec contains resolved ctx annotation and inferred types
+        assert len(ex._handler_specs) == 1
+        spec = ex._handler_specs[0]
+        assert spec["message_type"] is str
+        assert spec["output_types"] == [MyTypeA]
+        assert spec["workflow_output_types"] == [MyTypeB]
+
+    def test_handler_future_annotations_workflow_context_never_and_type(self) -> None:
+        class YieldOnlyExecutor(Executor):
+            @handler
+            async def example(self, input: str, ctx: WorkflowContext[Never, MyTypeB]) -> None:
+                pass
+
+        ex = YieldOnlyExecutor(id="y")
+
+        assert len(ex._handler_specs) == 1
+        spec = ex._handler_specs[0]
+        assert spec["message_type"] is str
+        assert spec["output_types"] == []
+        assert spec["workflow_output_types"] == [MyTypeB]

--- a/python/packages/core/tests/workflow/test_full_conversation.py
+++ b/python/packages/core/tests/workflow/test_full_conversation.py
@@ -362,9 +362,7 @@ async def test_run_request_with_full_history_clears_service_session_id() -> None
     """Replaying a full conversation (including function calls) via AgentExecutorRequest must
     clear service_session_id so the API does not receive both previous_response_id and the
     same function-call items in input — which would cause a 'Duplicate item' API error."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent", name="SpyAgent")
@@ -393,9 +391,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     """from_response hands off a prior agent's full conversation to the next executor.
     The receiving executor's service_session_id is preserved so the API can continue
     the conversation using previous_response_id."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent2", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent2", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent2")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent2", name="SpyAgent")
@@ -403,11 +399,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     # Simulate a prior run on the spy executor.
     spy_exec._session.service_session_id = "resp_PREVIOUS_RUN"  # pyright: ignore[reportPrivateUsage]
 
-    wf = (
-        WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec])
-        .add_edge(tool_exec, spy_exec)
-        .build()
-    )
+    wf = WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec]).add_edge(tool_exec, spy_exec).build()
 
     result = await wf.run("start")
     assert result.get_outputs() is not None


### PR DESCRIPTION
## Problem
`uv run mypy ...` failed because two pytest test methods in `test_executor_future.py` were missing return type annotations under `no-untyped-def`.

## Fix
Add `-> None` to:
- `test_handler_future_annotations_workflow_context_two_params`
- `test_handler_future_annotations_workflow_context_never_and_type`

## Verification
- `uv run ruff check ... --fix`
- `uv run mypy --config-file packages/core/pyproject.toml ...`
- `uv run pytest --import-mode=importlib -n logical --dist loadfile --dist worksteal packages/core/tests`