### PR TITLE
Fix Executor @handler validation with future annotations by resolving type hints

### DIFF
--- a/python/packages/core/tests/workflow/test_executor_future.py
+++ b/python/packages/core/tests/workflow/test_executor_future.py
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agent_framework import Executor, WorkflowContext, handler
+
+
+@dataclass
+class FutureTypeA:
+    value: str
+
+
+@dataclass
+class FutureTypeB:
+    value: int
+
+
+class TestExecutorFutureAnnotations:
+    """Regression tests for Executor @handler when annotations are stringified.
+
+    When `from __future__ import annotations` is enabled, parameter annotations
+    are stored as strings and must be resolved via typing.get_type_hints.
+    """
+
+    def test_handler_decorator_future_annotations_workflow_context_generic(self) -> None:
+        class MyExecutor(Executor):
+            @handler
+            async def example(self, input: str, ctx: WorkflowContext[FutureTypeA, FutureTypeB]) -> None:
+                pass
+
+        exec_instance = MyExecutor(id="test")
+        assert str in exec_instance._handlers
+
+        spec = exec_instance._handler_specs[0]
+        assert spec["message_type"] is str
+        assert spec["output_types"] == [FutureTypeA]
+        assert spec["workflow_output_types"] == [FutureTypeB]

--- a/python/packages/core/tests/workflow/test_full_conversation.py
+++ b/python/packages/core/tests/workflow/test_full_conversation.py
@@ -362,9 +362,7 @@ async def test_run_request_with_full_history_clears_service_session_id() -> None
     """Replaying a full conversation (including function calls) via AgentExecutorRequest must
     clear service_session_id so the API does not receive both previous_response_id and the
     same function-call items in input — which would cause a 'Duplicate item' API error."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent", name="SpyAgent")
@@ -393,9 +391,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     """from_response hands off a prior agent's full conversation to the next executor.
     The receiving executor's service_session_id is preserved so the API can continue
     the conversation using previous_response_id."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent2", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent2", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent2")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent2", name="SpyAgent")
@@ -403,11 +399,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     # Simulate a prior run on the spy executor.
     spy_exec._session.service_session_id = "resp_PREVIOUS_RUN"  # pyright: ignore[reportPrivateUsage]
 
-    wf = (
-        WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec])
-        .add_edge(tool_exec, spy_exec)
-        .build()
-    )
+    wf = WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec]).add_edge(tool_exec, spy_exec).build()
 
     result = await wf.run("start")
     assert result.get_outputs() is not None


### PR DESCRIPTION
### Problem
When `from __future__ import annotations` is enabled, handler parameter annotations are stored as strings. `Executor`’s `_validate_handler_signature` passed those raw string annotations into `validate_workflow_context_annotation`, which relies on `typing.get_origin/get_args` and fails to recognize `WorkflowContext[...]`.

### Fix
- In `python/packages/core/agent_framework/_workflows/_executor.py`, `_validate_handler_signature` now resolves annotations using `typing.get_type_hints` (preferring `include_extras=True` when available) and validates/infer types using the resolved hints.
- If type-hint resolution fails, it falls back to the previous raw-annotation behavior.

### Tests
- Added `python/packages/core/tests/workflow/test_executor_future.py` to reproduce the failure under `from __future__ import annotations` and assert correct handler registration and inferred `output_types` / `workflow_output_types`.

This makes class-based `Executor` behavior consistent with `FunctionExecutor`, fixing the reported failure mode without changing unrelated behavior.