### PR TITLE
Fix Executor @handler validation with postponed (string) annotations

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_executor.py
@@ -508,7 +508,7 @@ class Executor(RequestInfoMixin, DictConvertible):
         """Hook called when the workflow is restored from a checkpoint.
 
         Override this method in subclasses to implement custom logic that should
-        run when the workflow is restored from a checkpoint.
+        run when the workflow is restored from the checkpoint.
 
         Args:
             state: The state dictionary that was saved during checkpointing.
@@ -690,6 +690,10 @@ def handler(
 # region Handler Validation
 
 
+def _is_unresolved_type_hint(annotation: Any) -> bool:
+    return isinstance(annotation, str) or getattr(annotation, "__forward_arg__", None) is not None
+
+
 def _validate_handler_signature(
     func: Callable[..., Any],
     *,
@@ -709,6 +713,8 @@ def _validate_handler_signature(
     Raises:
         ValueError: If the function signature is invalid
     """
+    import typing
+
     signature = inspect.signature(func)
     params = list(signature.parameters.values())
 
@@ -717,25 +723,55 @@ def _validate_handler_signature(
     if len(params) != expected_counts:
         raise ValueError(f"Handler {func.__name__} must have {param_description}. Got {len(params)} parameters.")
 
-    # Check message parameter has type annotation (unless skipped)
+    # Best-effort type-hint resolution for postponed annotations (e.g., from __future__ import annotations).
+    # If resolution fails, *do not* silently fall back for ctx annotations, as that can leave a str/ForwardRef
+    # which will later fail validation with confusing errors.
+    type_hints: dict[str, Any] | None
+    try:
+        type_hints = typing.get_type_hints(
+            func,
+            globalns=getattr(func, "__globals__", None),
+            localns=None,
+            include_extras=True,
+        )
+    except (NameError, AttributeError, TypeError, ValueError):
+        # Expected failures when forward references cannot be resolved.
+        type_hints = None
+
     message_param = params[1]
-    if not skip_message_annotation and message_param.annotation == inspect.Parameter.empty:
+    ctx_param = params[2]
+
+    if type_hints is None:
+        resolved_message_annotation = message_param.annotation
+        resolved_ctx_annotation = ctx_param.annotation
+    else:
+        resolved_message_annotation = type_hints.get(message_param.name, message_param.annotation)
+        resolved_ctx_annotation = type_hints.get(ctx_param.name, ctx_param.annotation)
+
+    # Check message parameter has type annotation (unless skipped)
+    if not skip_message_annotation and resolved_message_annotation == inspect.Parameter.empty:
         raise ValueError(f"Handler {func.__name__} must have a type annotation for the message parameter")
 
     # Validate ctx parameter is WorkflowContext and extract type args
-    ctx_param = params[2]
-    if skip_message_annotation and ctx_param.annotation == inspect.Parameter.empty:
+    if skip_message_annotation and resolved_ctx_annotation == inspect.Parameter.empty:
         # When explicit types are provided via @handler(input=..., output=...),
         # the ctx parameter doesn't need a type annotation - types come from the decorator.
         output_types: list[type[Any] | types.UnionType] = []
         workflow_output_types: list[type[Any] | types.UnionType] = []
     else:
+        if _is_unresolved_type_hint(resolved_ctx_annotation):
+            raise ValueError(
+                f"Handler {func.__name__} has an unresolved type annotation for parameter '{ctx_param.name}': "
+                f"{resolved_ctx_annotation!r}. "
+                "Ensure referenced types are importable in the defining module, or avoid unresolved forward references "
+                "(especially under 'from __future__ import annotations')."
+            )
         output_types, workflow_output_types = validate_workflow_context_annotation(
-            ctx_param.annotation, f"parameter '{ctx_param.name}'", "Handler"
+            resolved_ctx_annotation, f"parameter '{ctx_param.name}'", "Handler"
         )
 
-    message_type = message_param.annotation if message_param.annotation != inspect.Parameter.empty else None
-    ctx_annotation = ctx_param.annotation
+    message_type = resolved_message_annotation if resolved_message_annotation != inspect.Parameter.empty else None
+    ctx_annotation = resolved_ctx_annotation
 
     return message_type, ctx_annotation, output_types, workflow_output_types
 

--- a/python/packages/core/tests/workflow/test_executor_future_annotations.py
+++ b/python/packages/core/tests/workflow/test_executor_future_annotations.py
@@ -1,0 +1,87 @@
+# Copyright (c) Microsoft. All rights reserved.
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from agent_framework import Executor, WorkflowContext, handler
+
+
+class MyTypeA(BaseModel):
+    pass
+
+
+class MyTypeB(BaseModel):
+    pass
+
+
+def test_handler_future_annotations_resolves_workflow_context_generics() -> None:
+    class MyExecutor(Executor):
+        @handler
+        async def example(self, input: str, ctx: WorkflowContext[MyTypeA, MyTypeB]) -> None:
+            pass
+
+    # Defining the class should not raise; instantiation triggers handler discovery.
+    e = MyExecutor(id="x")
+    assert e.output_types == [MyTypeA]
+    assert e.workflow_output_types == [MyTypeB]
+
+
+def test_handler_invalid_ctx_annotation_still_raises() -> None:
+    with pytest.raises(ValueError, match="must be annotated as WorkflowContext"):
+
+        class BadExecutor(Executor):
+            # Use explicit decorator types so mypy doesn't type-check ctx parameter as ContextT.
+            @handler(input=str)
+            async def example(self, input: Any, ctx: str) -> None:
+                pass
+
+            def __init__(self) -> None:
+                super().__init__(id="bad")
+
+        _ = BadExecutor()
+
+
+def test_handler_future_annotations_get_type_hints_failure_does_not_fallback_to_raw_ctx_annotation() -> None:
+    # Force typing.get_type_hints() to raise (NameError) due to unresolved forward ref in ctx annotation.
+    # Define the missing type only within the local scope so it's absent from function globals.
+    # The handler discovery should raise a targeted ValueError rather than letting a str/ForwardRef reach
+    # validate_workflow_context_annotation().
+    with pytest.raises(ValueError, match=r"unresolved type annotation.*parameter 'ctx'"):
+
+        class MyMissingType(BaseModel):
+            pass
+
+        class BadExecutor(Executor):
+            @handler
+            async def example(
+                self,
+                input: str,
+                ctx: WorkflowContext[MyMissingType, MyTypeB],  # noqa: F821
+            ) -> None:
+                pass
+
+        _ = BadExecutor(id="bad")
+
+
+def test_handler_future_annotations_message_enforcement_unchanged() -> None:
+    # Message annotation enforcement unchanged: missing message annotation should still raise.
+    with pytest.raises(ValueError, match="must have a type annotation for the message parameter"):
+
+        class BadExecutor(Executor):
+            @handler
+            async def example(self, input, ctx: WorkflowContext[MyTypeA]) -> None:  # type: ignore[no-untyped-def]
+                pass
+
+        _ = BadExecutor(id="bad")
+
+    # But when explicit decorator types are used, message annotation is skipped.
+    class OkExecutor(Executor):
+        @handler(input=str, output=MyTypeA)
+        async def example(self, input, ctx) -> None:  # type: ignore[no-untyped-def]
+            pass
+
+    e = OkExecutor(id="ok")
+    assert e.output_types == [MyTypeA]

--- a/python/packages/core/tests/workflow/test_full_conversation.py
+++ b/python/packages/core/tests/workflow/test_full_conversation.py
@@ -362,9 +362,7 @@ async def test_run_request_with_full_history_clears_service_session_id() -> None
     """Replaying a full conversation (including function calls) via AgentExecutorRequest must
     clear service_session_id so the API does not receive both previous_response_id and the
     same function-call items in input — which would cause a 'Duplicate item' API error."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent", name="SpyAgent")
@@ -393,9 +391,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     """from_response hands off a prior agent's full conversation to the next executor.
     The receiving executor's service_session_id is preserved so the API can continue
     the conversation using previous_response_id."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent2", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent2", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent2")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent2", name="SpyAgent")
@@ -403,11 +399,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     # Simulate a prior run on the spy executor.
     spy_exec._session.service_session_id = "resp_PREVIOUS_RUN"  # pyright: ignore[reportPrivateUsage]
 
-    wf = (
-        WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec])
-        .add_edge(tool_exec, spy_exec)
-        .build()
-    )
+    wf = WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec]).add_edge(tool_exec, spy_exec).build()
 
     result = await wf.run("start")
     assert result.get_outputs() is not None


### PR DESCRIPTION
### Problem
Using `from __future__ import annotations` stores annotations as strings. Executor handler signature validation forwarded the raw string `ctx` annotation into `validate_workflow_context_annotation()`, which relies on `typing.get_origin/get_args` and therefore rejected valid `WorkflowContext[T, U]` annotations.

### Fix
- Resolve handler annotations in `_validate_handler_signature` via `typing.get_type_hints(..., include_extras=True)` (best-effort; falls back to raw annotations on failure).
- Validate `WorkflowContext` using the resolved annotation.

### Tests
- Added a regression test ensuring a handler annotated as `WorkflowContext[MyTypeA, MyTypeB]` under `__future__.annotations` does not raise and correctly infers `output_types` / `workflow_output_types`.
- Added a test ensuring invalid ctx annotations still raise the expected ValueError.