### PR TITLE
Fix Executor @handler validation with postponed annotations (future annotations)

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_executor.py
@@ -717,25 +717,34 @@ def _validate_handler_signature(
     if len(params) != expected_counts:
         raise ValueError(f"Handler {func.__name__} must have {param_description}. Got {len(params)} parameters.")
 
+    type_hints: dict[str, Any] = {}
+    # Resolve postponed annotations (e.g. `from __future__ import annotations`).
+    # Fall back to raw annotations if resolution fails.
+    try:
+        type_hints = inspect.get_annotations(func, eval_str=True)
+    except Exception:
+        type_hints = {}
+
     # Check message parameter has type annotation (unless skipped)
     message_param = params[1]
-    if not skip_message_annotation and message_param.annotation == inspect.Parameter.empty:
+    message_annotation = type_hints.get(message_param.name, message_param.annotation)
+    if not skip_message_annotation and message_annotation == inspect.Parameter.empty:
         raise ValueError(f"Handler {func.__name__} must have a type annotation for the message parameter")
 
     # Validate ctx parameter is WorkflowContext and extract type args
     ctx_param = params[2]
-    if skip_message_annotation and ctx_param.annotation == inspect.Parameter.empty:
+    ctx_annotation = type_hints.get(ctx_param.name, ctx_param.annotation)
+    if skip_message_annotation and ctx_annotation == inspect.Parameter.empty:
         # When explicit types are provided via @handler(input=..., output=...),
         # the ctx parameter doesn't need a type annotation - types come from the decorator.
         output_types: list[type[Any] | types.UnionType] = []
         workflow_output_types: list[type[Any] | types.UnionType] = []
     else:
         output_types, workflow_output_types = validate_workflow_context_annotation(
-            ctx_param.annotation, f"parameter '{ctx_param.name}'", "Handler"
+            ctx_annotation, f"parameter '{ctx_param.name}'", "Handler"
         )
 
-    message_type = message_param.annotation if message_param.annotation != inspect.Parameter.empty else None
-    ctx_annotation = ctx_param.annotation
+    message_type = message_annotation if message_annotation != inspect.Parameter.empty else None
 
     return message_type, ctx_annotation, output_types, workflow_output_types
 

--- a/python/packages/core/tests/workflow/test_executor_future.py
+++ b/python/packages/core/tests/workflow/test_executor_future.py
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+from agent_framework import Executor, WorkflowContext, handler
+
+
+@dataclass
+class TypeA:
+    value: str
+
+
+@dataclass
+class TypeB:
+    value: int
+
+
+class TestExecutorFutureAnnotations:
+    """Test suite for Executor @handler with from __future__ import annotations."""
+
+    def test_handler_future_annotations_workflow_context_generics(self) -> None:
+        class MyExecutor(Executor):
+            @handler
+            async def example(self, input: str, ctx: WorkflowContext[TypeA, TypeB]) -> None:
+                pass
+
+        exec_instance = MyExecutor(id="future")
+
+        handler_func = exec_instance._handlers[str]
+        spec = cast(dict[str, Any], handler_func._handler_spec)
+
+        assert spec["message_type"] is str
+        assert spec["output_types"] == [TypeA]
+        assert spec["workflow_output_types"] == [TypeB]

--- a/python/packages/core/tests/workflow/test_full_conversation.py
+++ b/python/packages/core/tests/workflow/test_full_conversation.py
@@ -362,9 +362,7 @@ async def test_run_request_with_full_history_clears_service_session_id() -> None
     """Replaying a full conversation (including function calls) via AgentExecutorRequest must
     clear service_session_id so the API does not receive both previous_response_id and the
     same function-call items in input — which would cause a 'Duplicate item' API error."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent", name="SpyAgent")
@@ -393,9 +391,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     """from_response hands off a prior agent's full conversation to the next executor.
     The receiving executor's service_session_id is preserved so the API can continue
     the conversation using previous_response_id."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent2", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent2", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent2")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent2", name="SpyAgent")
@@ -403,11 +399,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     # Simulate a prior run on the spy executor.
     spy_exec._session.service_session_id = "resp_PREVIOUS_RUN"  # pyright: ignore[reportPrivateUsage]
 
-    wf = (
-        WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec])
-        .add_edge(tool_exec, spy_exec)
-        .build()
-    )
+    wf = WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec]).add_edge(tool_exec, spy_exec).build()
 
     result = await wf.run("start")
     assert result.get_outputs() is not None


### PR DESCRIPTION
### Problem
When `from __future__ import annotations` is enabled, handler parameter annotations are stored as strings. Executor handler signature validation used raw `inspect.signature(...).annotation` values, passing string annotations into `validate_workflow_context_annotation`, which then failed because `typing.get_origin()` cannot inspect `str`.

### Fix
- Resolve annotations in `_validate_handler_signature` via `inspect.get_annotations(..., eval_str=True)`.
- Validate and return message/context annotations using the resolved values.

### Tests
- Added `test_executor_future.py` to assert `WorkflowContext[TypeA, TypeB]` is properly validated and inferred into `output_types` / `workflow_output_types` under postponed annotations.