### PR TITLE
Fix @handler validation for postponed (future) annotations in Executor

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_executor.py
@@ -722,20 +722,38 @@ def _validate_handler_signature(
     if not skip_message_annotation and message_param.annotation == inspect.Parameter.empty:
         raise ValueError(f"Handler {func.__name__} must have a type annotation for the message parameter")
 
+    # Resolve postponed annotations (from __future__ import annotations) and forward refs.
+    # typing.get_type_hints mirrors Python's own behavior and will turn strings into real typing objects.
+    try:
+        import typing
+
+        type_hints = typing.get_type_hints(func, include_extras=True)
+    except TypeError:
+        # include_extras not supported (older typing / python)
+        import typing
+
+        type_hints = typing.get_type_hints(func)
+    except Exception:
+        type_hints = {}
+
+    resolved_message_annotation = type_hints.get(message_param.name, message_param.annotation)
+
     # Validate ctx parameter is WorkflowContext and extract type args
     ctx_param = params[2]
-    if skip_message_annotation and ctx_param.annotation == inspect.Parameter.empty:
+    resolved_ctx_annotation = type_hints.get(ctx_param.name, ctx_param.annotation)
+
+    if skip_message_annotation and resolved_ctx_annotation == inspect.Parameter.empty:
         # When explicit types are provided via @handler(input=..., output=...),
         # the ctx parameter doesn't need a type annotation - types come from the decorator.
         output_types: list[type[Any] | types.UnionType] = []
         workflow_output_types: list[type[Any] | types.UnionType] = []
     else:
         output_types, workflow_output_types = validate_workflow_context_annotation(
-            ctx_param.annotation, f"parameter '{ctx_param.name}'", "Handler"
+            resolved_ctx_annotation, f"parameter '{ctx_param.name}'", "Handler"
         )
 
-    message_type = message_param.annotation if message_param.annotation != inspect.Parameter.empty else None
-    ctx_annotation = ctx_param.annotation
+    message_type = resolved_message_annotation if resolved_message_annotation != inspect.Parameter.empty else None
+    ctx_annotation = resolved_ctx_annotation
 
     return message_type, ctx_annotation, output_types, workflow_output_types
 

--- a/python/packages/core/tests/workflow/test_executor_future.py
+++ b/python/packages/core/tests/workflow/test_executor_future.py
@@ -1,0 +1,35 @@
+# Copyright (c) Microsoft. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agent_framework import Executor, WorkflowContext, handler
+
+
+@dataclass
+class MyTypeA:
+    value: str
+
+
+@dataclass
+class MyTypeB:
+    value: int
+
+
+class TestExecutorFutureAnnotations:
+    def test_handler_decorator_future_annotations_resolves_workflow_context(self) -> None:
+        class MyExecutor(Executor):
+            @handler
+            async def example(self, input: str, ctx: WorkflowContext[MyTypeA, MyTypeB]) -> None:
+                pass
+
+        # Instantiation triggers handler discovery/validation.
+        executor = MyExecutor(id="test")
+
+        handler_func = executor._handlers[str]
+        spec = getattr(handler_func, "_handler_spec", None)
+
+        assert isinstance(spec, dict)
+        assert spec["message_type"] is str
+        assert spec["output_types"] == [MyTypeA]
+        assert spec["workflow_output_types"] == [MyTypeB]

--- a/python/packages/core/tests/workflow/test_full_conversation.py
+++ b/python/packages/core/tests/workflow/test_full_conversation.py
@@ -362,9 +362,7 @@ async def test_run_request_with_full_history_clears_service_session_id() -> None
     """Replaying a full conversation (including function calls) via AgentExecutorRequest must
     clear service_session_id so the API does not receive both previous_response_id and the
     same function-call items in input — which would cause a 'Duplicate item' API error."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent", name="SpyAgent")
@@ -393,9 +391,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     """from_response hands off a prior agent's full conversation to the next executor.
     The receiving executor's service_session_id is preserved so the API can continue
     the conversation using previous_response_id."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent2", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent2", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent2")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent2", name="SpyAgent")
@@ -403,11 +399,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     # Simulate a prior run on the spy executor.
     spy_exec._session.service_session_id = "resp_PREVIOUS_RUN"  # pyright: ignore[reportPrivateUsage]
 
-    wf = (
-        WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec])
-        .add_edge(tool_exec, spy_exec)
-        .build()
-    )
+    wf = WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec]).add_edge(tool_exec, spy_exec).build()
 
     result = await wf.run("start")
     assert result.get_outputs() is not None


### PR DESCRIPTION
### Problem
Using `from __future__ import annotations` stores annotations as strings. The `Executor` handler signature validation path used raw `inspect.signature(...).parameters[i].annotation`, passing a string into `validate_workflow_context_annotation`, which relies on `typing.get_origin/get_args` and therefore rejected valid `WorkflowContext[T, U]` annotations.

### Fix
- Resolve handler annotations in `_validate_handler_signature` using `typing.get_type_hints(..., include_extras=True)` (with compatibility fallback).
- Validate WorkflowContext using the resolved annotation, ensuring `WorkflowContext[MyTypeA, MyTypeB]` is recognized under postponed evaluation.

### Tests
- Added `test_executor_future.py` to ensure an Executor with a `@handler` method under `from __future__ import annotations` can be instantiated and correctly infers output/workflow_output types from `WorkflowContext[T, U]`.

### Scope
Minimal change limited to Executor handler signature validation; no changes to WorkflowContext validation logic.