### PR TITLE
Fix Executor @handler validation with postponed (future) annotations

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_executor.py
@@ -7,7 +7,7 @@ import inspect
 import logging
 import types
 from collections.abc import Awaitable, Callable
-from typing import Any, TypeVar, overload
+from typing import Any, TypeVar, get_type_hints, overload
 
 from ..observability import create_processing_span
 from ._events import (
@@ -508,7 +508,7 @@ class Executor(RequestInfoMixin, DictConvertible):
         """Hook called when the workflow is restored from a checkpoint.
 
         Override this method in subclasses to implement custom logic that should
-        run when the workflow is restored from a checkpoint.
+        run when the workflow is restored from the checkpoint.
 
         Args:
             state: The state dictionary that was saved during checkpointing.
@@ -717,25 +717,40 @@ def _validate_handler_signature(
     if len(params) != expected_counts:
         raise ValueError(f"Handler {func.__name__} must have {param_description}. Got {len(params)} parameters.")
 
+    # Resolve postponed annotations (from __future__ import annotations) and forward refs.
+    # We need the resolved typing objects for WorkflowContext validation and handler registration.
+    resolved_hints: dict[str, Any] = {}
+    with contextlib.suppress(NameError, TypeError, AttributeError):
+        resolved_hints = get_type_hints(func, globalns=getattr(func, "__globals__", None), include_extras=True)
+
     # Check message parameter has type annotation (unless skipped)
     message_param = params[1]
-    if not skip_message_annotation and message_param.annotation == inspect.Parameter.empty:
+    message_annotation = resolved_hints.get(message_param.name, message_param.annotation)
+    if (not skip_message_annotation) and message_annotation == inspect.Parameter.empty:
         raise ValueError(f"Handler {func.__name__} must have a type annotation for the message parameter")
 
     # Validate ctx parameter is WorkflowContext and extract type args
     ctx_param = params[2]
-    if skip_message_annotation and ctx_param.annotation == inspect.Parameter.empty:
+    ctx_annotation = resolved_hints.get(ctx_param.name, ctx_param.annotation)
+
+    output_types: list[type[Any] | types.UnionType]
+    workflow_output_types: list[type[Any] | types.UnionType]
+    if skip_message_annotation and ctx_annotation == inspect.Parameter.empty:
         # When explicit types are provided via @handler(input=..., output=...),
         # the ctx parameter doesn't need a type annotation - types come from the decorator.
-        output_types: list[type[Any] | types.UnionType] = []
-        workflow_output_types: list[type[Any] | types.UnionType] = []
+        output_types = []
+        workflow_output_types = []
     else:
+        # Best-effort resolution for string annotations if get_type_hints didn't resolve.
+        # This can happen in some edge cases (e.g., missing globals) but we still have
+        # func.__globals__ available here.
+        if isinstance(ctx_annotation, str):
+            ctx_annotation = resolve_type_annotation(ctx_annotation, getattr(func, "__globals__", None))
         output_types, workflow_output_types = validate_workflow_context_annotation(
-            ctx_param.annotation, f"parameter '{ctx_param.name}'", "Handler"
+            ctx_annotation, f"parameter '{ctx_param.name}'", "Handler"
         )
 
-    message_type = message_param.annotation if message_param.annotation != inspect.Parameter.empty else None
-    ctx_annotation = ctx_param.annotation
+    message_type = message_annotation if message_annotation != inspect.Parameter.empty else None
 
     return message_type, ctx_annotation, output_types, workflow_output_types
 

--- a/python/packages/core/tests/workflow/test_executor_future.py
+++ b/python/packages/core/tests/workflow/test_executor_future.py
@@ -1,0 +1,46 @@
+# Copyright (c) Microsoft. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agent_framework import Executor, WorkflowContext, WorkflowMessage, handler
+
+
+@dataclass
+class FutureMsg:
+    value: int
+
+
+@dataclass
+class FutureTypeA:
+    value: str
+
+
+@dataclass
+class FutureTypeB:
+    value: int
+
+
+def test_executor_handler_future_annotations_workflow_context_generics_are_resolved() -> None:
+    """Regression test: @handler should work when annotations are strings (PEP563)."""
+
+    class MyExecutor(Executor):
+        @handler
+        async def example(self, message: FutureMsg, ctx: WorkflowContext[FutureTypeA, FutureTypeB]) -> None:
+            pass
+
+    ex = MyExecutor(id="my")
+
+    # Ensure handler registration uses real types (not string annotations)
+    assert FutureMsg in ex._handlers
+
+    handler_func = ex._handlers[FutureMsg]
+    assert hasattr(handler_func, "_handler_spec")
+    spec = handler_func._handler_spec  # type: ignore[attr-defined]
+
+    assert spec["message_type"] is FutureMsg
+    assert spec["output_types"] == [FutureTypeA]
+    assert spec["workflow_output_types"] == [FutureTypeB]
+
+    # And can_handle still works
+    assert ex.can_handle(WorkflowMessage(data=FutureMsg(1), source_id="mock"))

--- a/python/packages/core/tests/workflow/test_full_conversation.py
+++ b/python/packages/core/tests/workflow/test_full_conversation.py
@@ -362,9 +362,7 @@ async def test_run_request_with_full_history_clears_service_session_id() -> None
     """Replaying a full conversation (including function calls) via AgentExecutorRequest must
     clear service_session_id so the API does not receive both previous_response_id and the
     same function-call items in input — which would cause a 'Duplicate item' API error."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent", name="SpyAgent")
@@ -393,9 +391,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     """from_response hands off a prior agent's full conversation to the next executor.
     The receiving executor's service_session_id is preserved so the API can continue
     the conversation using previous_response_id."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent2", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent2", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent2")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent2", name="SpyAgent")
@@ -403,11 +399,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     # Simulate a prior run on the spy executor.
     spy_exec._session.service_session_id = "resp_PREVIOUS_RUN"  # pyright: ignore[reportPrivateUsage]
 
-    wf = (
-        WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec])
-        .add_edge(tool_exec, spy_exec)
-        .build()
-    )
+    wf = WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec]).add_edge(tool_exec, spy_exec).build()
 
     result = await wf.run("start")
     assert result.get_outputs() is not None


### PR DESCRIPTION
### Problem
`Executor` handler introspection/validation used raw `inspect.signature` annotations. Under `from __future__ import annotations`, these are strings, causing `validate_workflow_context_annotation()` to fail because `typing.get_origin()` cannot interpret a string.

### Fix
- In `_validate_handler_signature()` resolve postponed/forward-ref annotations with `typing.get_type_hints(..., include_extras=True)`.
- Use resolved annotations for:
  - message_type returned/registered in handler specs
  - ctx annotation passed to `validate_workflow_context_annotation()`
- Add best-effort fallback using `resolve_type_annotation()` when ctx remains a string.

### Tests
- Added `test_executor_future.py` to cover `@handler` on `Executor` classes with `from __future__ import annotations`, asserting correct handler registration and inferred output/workflow output types.

### Scope
Change is limited to Executor handler signature validation path; no changes to WorkflowContext validator logic.