### PR TITLE
Fix Executor handler validation for postponed annotations (future annotations)

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_executor.py
@@ -508,7 +508,7 @@ class Executor(RequestInfoMixin, DictConvertible):
         """Hook called when the workflow is restored from a checkpoint.
 
         Override this method in subclasses to implement custom logic that should
-        run when the workflow is restored from a checkpoint.
+        run when the workflow is restored from the checkpoint.
 
         Args:
             state: The state dictionary that was saved during checkpointing.
@@ -623,7 +623,7 @@ def handler(
 
             # Validate signature structure (correct number of params, ctx is WorkflowContext)
             # but skip type extraction since we're using explicit types
-            _validate_handler_signature(func, skip_message_annotation=True)
+            _, resolved_ctx_annotation, _, _ = _validate_handler_signature(func, skip_message_annotation=True)
 
             # Use explicit types only - missing params default to empty
             message_type = resolved_input_type
@@ -634,10 +634,8 @@ def handler(
             final_workflow_output_types = (
                 normalize_type_to_list(resolved_workflow_output_type) if resolved_workflow_output_type else []
             )
-            # Get ctx_annotation for consistency (even though types come from explicit params)
-            ctx_annotation = (
-                inspect.signature(func).parameters[list(inspect.signature(func).parameters.keys())[2]].annotation
-            )
+            # Keep resolved ctx annotation (may be empty if user omitted annotation)
+            ctx_annotation = resolved_ctx_annotation
         else:
             # Use introspection for ALL types - no explicit params provided
             introspected_message_type, ctx_annotation, inferred_output_types, inferred_workflow_output_types = (
@@ -717,25 +715,45 @@ def _validate_handler_signature(
     if len(params) != expected_counts:
         raise ValueError(f"Handler {func.__name__} must have {param_description}. Got {len(params)} parameters.")
 
+    # Best-effort resolve postponed annotations (from __future__ import annotations)
+    # so downstream validators see real typing objects rather than strings.
+    try:
+        import typing
+
+        type_hints = typing.get_type_hints(func, include_extras=True)
+    except TypeError:
+        # include_extras not supported
+        try:
+            import typing
+
+            type_hints = typing.get_type_hints(func)
+        except Exception:
+            type_hints = {}
+    except Exception:
+        type_hints = {}
+
     # Check message parameter has type annotation (unless skipped)
     message_param = params[1]
     if not skip_message_annotation and message_param.annotation == inspect.Parameter.empty:
         raise ValueError(f"Handler {func.__name__} must have a type annotation for the message parameter")
 
+    message_type = type_hints.get(message_param.name, message_param.annotation)
+    if message_type == inspect.Parameter.empty:
+        message_type = None
+
     # Validate ctx parameter is WorkflowContext and extract type args
     ctx_param = params[2]
-    if skip_message_annotation and ctx_param.annotation == inspect.Parameter.empty:
+    ctx_annotation = type_hints.get(ctx_param.name, ctx_param.annotation)
+
+    if skip_message_annotation and ctx_annotation == inspect.Parameter.empty:
         # When explicit types are provided via @handler(input=..., output=...),
         # the ctx parameter doesn't need a type annotation - types come from the decorator.
         output_types: list[type[Any] | types.UnionType] = []
         workflow_output_types: list[type[Any] | types.UnionType] = []
     else:
         output_types, workflow_output_types = validate_workflow_context_annotation(
-            ctx_param.annotation, f"parameter '{ctx_param.name}'", "Handler"
+            ctx_annotation, f"parameter '{ctx_param.name}'", "Handler"
         )
-
-    message_type = message_param.annotation if message_param.annotation != inspect.Parameter.empty else None
-    ctx_annotation = ctx_param.annotation
 
     return message_type, ctx_annotation, output_types, workflow_output_types
 

--- a/python/packages/core/tests/workflow/test_executor_future.py
+++ b/python/packages/core/tests/workflow/test_executor_future.py
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from typing_extensions import Never
+
+from agent_framework import Executor, WorkflowContext, handler
+
+
+@dataclass
+class TypeA:
+    value: int
+
+
+@dataclass
+class TypeB:
+    value: str
+
+
+class TestExecutorFutureAnnotations:
+    """Regression tests for Executor handler validation with postponed (string) annotations."""
+
+    def test_handler_future_annotations_workflow_context_two_args(self) -> None:
+        class FutureTwoArgsExecutor(Executor):
+            @handler
+            async def handle(self, message: str, ctx: WorkflowContext[TypeA, TypeB]) -> None:
+                pass
+
+        ex = FutureTwoArgsExecutor(id="future_two")
+        assert set(ex.output_types) == {TypeA}
+        assert set(ex.workflow_output_types) == {TypeB}
+
+    def test_handler_future_annotations_workflow_context_union_args(self) -> None:
+        class FutureUnionArgsExecutor(Executor):
+            @handler
+            async def handle(self, message: str, ctx: WorkflowContext[TypeA | TypeB, Never]) -> None:
+                pass
+
+        ex = FutureUnionArgsExecutor(id="future_union")
+        assert set(ex.output_types) == {TypeA, TypeB}
+        assert ex.workflow_output_types == []

--- a/python/packages/core/tests/workflow/test_full_conversation.py
+++ b/python/packages/core/tests/workflow/test_full_conversation.py
@@ -362,9 +362,7 @@ async def test_run_request_with_full_history_clears_service_session_id() -> None
     """Replaying a full conversation (including function calls) via AgentExecutorRequest must
     clear service_session_id so the API does not receive both previous_response_id and the
     same function-call items in input — which would cause a 'Duplicate item' API error."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent", name="SpyAgent")
@@ -393,9 +391,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     """from_response hands off a prior agent's full conversation to the next executor.
     The receiving executor's service_session_id is preserved so the API can continue
     the conversation using previous_response_id."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent2", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent2", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent2")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent2", name="SpyAgent")
@@ -403,11 +399,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     # Simulate a prior run on the spy executor.
     spy_exec._session.service_session_id = "resp_PREVIOUS_RUN"  # pyright: ignore[reportPrivateUsage]
 
-    wf = (
-        WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec])
-        .add_edge(tool_exec, spy_exec)
-        .build()
-    )
+    wf = WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec]).add_edge(tool_exec, spy_exec).build()
 
     result = await wf.run("start")
     assert result.get_outputs() is not None


### PR DESCRIPTION
## Problem
When `from __future__ import annotations` is enabled, Executor handler parameter annotations are strings. `_validate_handler_signature` passed these strings into `validate_workflow_context_annotation`, causing `WorkflowContext[T, U]` validation to fail with `ValueError`.

## Fix
- Resolve handler annotations inside `_validate_handler_signature` using `typing.get_type_hints` (best-effort; falls back to raw annotations on resolution errors).
- Validate `WorkflowContext[...]` using the resolved type hint instead of the raw string.
- Store the resolved `ctx_annotation` in the handler spec (including explicit-type mode).

## Tests
Added `test_executor_future.py` to ensure that handlers defined under postponed annotations validate successfully and that `output_types` / `workflow_output_types` are inferred correctly for:
- `WorkflowContext[TypeA, TypeB]`
- `WorkflowContext[TypeA | TypeB, Never]`