### PR TITLE
Fix Executor @handler validation with postponed annotations (future annotations)

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_executor.py
@@ -722,6 +722,19 @@ def _validate_handler_signature(
     if not skip_message_annotation and message_param.annotation == inspect.Parameter.empty:
         raise ValueError(f"Handler {func.__name__} must have a type annotation for the message parameter")
 
+    # typing.get_type_hints resolves stringified/postponed annotations
+    try:
+        import typing
+
+        type_hints = typing.get_type_hints(func)
+    except Exception:
+        # Fall back to raw annotations if hints cannot be resolved (e.g., unresolved forward refs)
+        type_hints = {}
+
+    message_type = type_hints.get(message_param.name, message_param.annotation)
+    if message_type == inspect.Parameter.empty:
+        message_type = None
+
     # Validate ctx parameter is WorkflowContext and extract type args
     ctx_param = params[2]
     if skip_message_annotation and ctx_param.annotation == inspect.Parameter.empty:
@@ -729,13 +742,12 @@ def _validate_handler_signature(
         # the ctx parameter doesn't need a type annotation - types come from the decorator.
         output_types: list[type[Any] | types.UnionType] = []
         workflow_output_types: list[type[Any] | types.UnionType] = []
+        ctx_annotation = ctx_param.annotation
     else:
+        ctx_annotation = type_hints.get(ctx_param.name, ctx_param.annotation)
         output_types, workflow_output_types = validate_workflow_context_annotation(
-            ctx_param.annotation, f"parameter '{ctx_param.name}'", "Handler"
+            ctx_annotation, f"parameter '{ctx_param.name}'", "Handler"
         )
-
-    message_type = message_param.annotation if message_param.annotation != inspect.Parameter.empty else None
-    ctx_annotation = ctx_param.annotation
 
     return message_type, ctx_annotation, output_types, workflow_output_types
 

--- a/python/packages/core/tests/workflow/test_executor_future.py
+++ b/python/packages/core/tests/workflow/test_executor_future.py
@@ -1,0 +1,50 @@
+# Copyright (c) Microsoft. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agent_framework import Executor, WorkflowContext, handler
+
+
+@dataclass
+class MyTypeA:
+    value: str
+
+
+@dataclass
+class MyTypeB:
+    value: int
+
+
+class TestExecutorFutureAnnotations:
+    """Regression tests for Executor/@handler with postponed (string) annotations."""
+
+    def test_handler_future_annotations_workflow_context_two_params(self) -> None:
+        class MyExecutor(Executor):
+            @handler
+            async def example(self, input: str, ctx: WorkflowContext[MyTypeA, MyTypeB]) -> None:
+                pass
+
+        exec_instance = MyExecutor(id="future_exec")
+
+        # Handler is registered for str input
+        assert str in exec_instance._handlers
+
+        # Ensure ctx annotation was resolved and output types were inferred
+        spec = exec_instance._handler_specs[0]
+        assert spec["ctx_annotation"] == WorkflowContext[MyTypeA, MyTypeB]
+        assert spec["output_types"] == [MyTypeA]
+        assert spec["workflow_output_types"] == [MyTypeB]
+
+    def test_handler_future_annotations_workflow_context_one_param(self) -> None:
+        class MyExecutor(Executor):
+            @handler
+            async def example(self, input: str, ctx: WorkflowContext[MyTypeA]) -> None:
+                pass
+
+        exec_instance = MyExecutor(id="future_exec_one")
+
+        spec = exec_instance._handler_specs[0]
+        assert spec["ctx_annotation"] == WorkflowContext[MyTypeA]
+        assert spec["output_types"] == [MyTypeA]
+        assert spec["workflow_output_types"] == []

--- a/python/packages/core/tests/workflow/test_full_conversation.py
+++ b/python/packages/core/tests/workflow/test_full_conversation.py
@@ -362,9 +362,7 @@ async def test_run_request_with_full_history_clears_service_session_id() -> None
     """Replaying a full conversation (including function calls) via AgentExecutorRequest must
     clear service_session_id so the API does not receive both previous_response_id and the
     same function-call items in input — which would cause a 'Duplicate item' API error."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent", name="SpyAgent")
@@ -393,9 +391,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     """from_response hands off a prior agent's full conversation to the next executor.
     The receiving executor's service_session_id is preserved so the API can continue
     the conversation using previous_response_id."""
-    tool_agent = _ToolHistoryAgent(
-        id="tool_agent2", name="ToolAgent", summary_text="Done."
-    )
+    tool_agent = _ToolHistoryAgent(id="tool_agent2", name="ToolAgent", summary_text="Done.")
     tool_exec = AgentExecutor(tool_agent, id="tool_agent2")
 
     spy_agent = _SessionIdCapturingAgent(id="spy_agent2", name="SpyAgent")
@@ -403,11 +399,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     # Simulate a prior run on the spy executor.
     spy_exec._session.service_session_id = "resp_PREVIOUS_RUN"  # pyright: ignore[reportPrivateUsage]
 
-    wf = (
-        WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec])
-        .add_edge(tool_exec, spy_exec)
-        .build()
-    )
+    wf = WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec]).add_edge(tool_exec, spy_exec).build()
 
     result = await wf.run("start")
     assert result.get_outputs() is not None


### PR DESCRIPTION
### Problem
When `from __future__ import annotations` is enabled, annotations are stored as strings. Executor’s `_validate_handler_signature` validated `ctx` using the raw string annotation, causing `validate_workflow_context_annotation` to reject valid `WorkflowContext[T]` / `WorkflowContext[T, U]` annotations.

### Fix
- Resolve annotations with `typing.get_type_hints(func)` inside `_validate_handler_signature`.
- Use resolved hints for both message and ctx annotation validation.
- If type hints cannot be resolved (e.g., unresolved forward refs), fall back to existing raw annotation behavior.

### Tests
Added `test_executor_future.py` covering `WorkflowContext[T]` and `WorkflowContext[T, U]` under postponed annotations; these fail before the fix and pass after.